### PR TITLE
Fixed "Configuring the Python Interpreter" section

### DIFF
--- a/content/anaconda_settings.md
+++ b/content/anaconda_settings.md
@@ -142,8 +142,11 @@ Exaple of project configuration (~/projects/my_project/MyProject.sublime-project
             "follow_symlinks": true,
             "path": "."
         }
-    ]
-    "python_interpreter": "~/virtualenvs/my_project/bin/python"
+    ],
+    "settings":
+    {
+        "python_interpreter": "~/virtualenvs/my_project/bin/python"
+    }
 }
 ```
 


### PR DESCRIPTION
the "python_interpreter" setting was in the global scope in this section, even though it was talking about a project configuration. It's now correctly moved into a `"settings"` dict