### PR TITLE
[Fix] Caption in command palette

### DIFF
--- a/content/IDE.md
+++ b/content/IDE.md
@@ -165,7 +165,7 @@ The command can be triggered with:
 
 * Keyboard: `ctrl+alt+d`
 * Context Menu: `Anaconda > Show Documentation`
-* Command Palette: `Command Palatte > Anaconda: Show`
+* Command Palette: `Command Palette > Anaconda: Display Object Docs`
 
 # Refactor Rename
 


### PR DESCRIPTION
I look [**`Context.sublime-menu`**](https://github.com/DamnWidget/anaconda/blob/master/Context.sublime-menu#L22-L26) file and saw, that for documentation showing use command `anaconda_doc`.

I added correct caption in command palette for `anaconda_doc` command. See [**`Default.sublime-commands`**](https://github.com/DamnWidget/anaconda/blob/master/Default.sublime-commands#L70-L73) file.

Thanks.